### PR TITLE
Renaming of glib packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["libnotify", "notification"]
 
 [dependencies]
 libnotify-sys = "*"
-glib-2_0-sys = "*"
+glib-2-0-sys = "*"
 gtypes = "*"


### PR DESCRIPTION
I'm going to normalize the package names in gi-rust, while also switching
to generated code that provides nearly all of the library API. This
package is one of the few that depends on the current name.

If you need coordination in having this patch applied together with publishing the new gi-rust crates (currently on hold due to the extant dependencies), please contact me on `irc.mozilla.org` by username `mzabaluev`.
