### PR TITLE
Updating Cargo.toml dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ gdk-pixbuf-sys = "0.4.0"
 glib = "0.3.1"
 glib-sys = "0.4.0"
 gobject-sys = "0.4.0"
-libnotify-sys = "1.0.0"
+libnotify-sys = { path = "libnotify-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,17 @@
 [package]
-name = "libnotify"
-version = "1.0.1"
 authors = ["Mika Attila <radiantstatue@gmail.com>", "Julian Ospald <hasufell@posteo.de>"]
-license = "MIT"
 description = "Rust bindings to libnotify"
-readme = "README.md"
-repository = "https://github.com/hasufell/rust-libnotify"
 documentation = "https://hasufell.github.io/rust-libnotify/libnotify/"
 keywords = ["libnotify", "notification"]
-
+license = "MIT"
+name = "libnotify"
+readme = "README.md"
+repository = "https://github.com/hasufell/rust-libnotify"
+version = "1.0.1"
 [dependencies]
-gdk-pixbuf = "^0.1.3"
-gdk-pixbuf-sys = "^0.3.4"
-glib = "^0.1.3"
-glib-sys = "^0.3.4"
-gobject-sys = "^0.3.4"
-libnotify-sys = "^1.0.0"
+gdk-pixbuf = "0.2.0"
+gdk-pixbuf-sys = "0.4.0"
+glib = "0.3.1"
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
+libnotify-sys = "1.0.0"

--- a/libnotify-sys/Cargo.toml
+++ b/libnotify-sys/Cargo.toml
@@ -1,22 +1,3 @@
-[build-dependencies]
-pkg-config = ">=0.3.7"
-
-[dependencies]
-bitflags = "^0.9.0"
-libc = "^0.2.0"
-
-[dependencies.gdk-pixbuf-sys]
-version = "^0.3.4"
-
-[dependencies.glib-sys]
-version = "^0.3.4"
-
-[dependencies.gobject-sys]
-version = "^0.3.4"
-
-[lib]
-name = "libnotify_sys"
-
 [package]
 authors = ["Mika Attila <radiantstatue@gmail.com>", "Julian Ospald <hasufell@posteo.de>"]
 build = "build.rs"
@@ -28,3 +9,15 @@ name = "libnotify-sys"
 readme = "README.md"
 repository = "https://github.com/hasufell/rust-libnotify"
 version = "1.0.0"
+[build-dependencies]
+pkg-config = "0.3.9"
+
+[dependencies]
+bitflags = "0.9.1"
+gdk-pixbuf-sys = "0.4.0"
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
+libc = "0.2.30"
+
+[lib]
+name = "libnotify_sys"


### PR DESCRIPTION
The current version doesn't work with a project with the last version of gtk-rs because of conflicts between glib-sys required by the current version of gtk-rs and the glib-sys version required by rust-libnotify.

Upgrading all dependencies fixes this issue.